### PR TITLE
Support async pause/sleep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["/.github/*", "/.travis.yml", "/appveyor.yml"]
 log = { version = "0.4", features = ["std"] }
 once_cell = "1.9.0"
 rand = "0.8"
+tokio = { version = "1.40.0", features = ["sync", "time", "rt", "macros", "test-util"] }
 
 [features]
 failpoints = []


### PR DESCRIPTION
This patch adds the ability to use asynchronous sleeping and pausing in async test cases. Here is an example test case which uses this capability: https://github.com/hachikuji/slatedb/commit/0c7ae48c1f4da3498ccb8d03893a0529fa3aad49.