### PR TITLE
Bump rand 0.8 → 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/.github/*", "/.travis.yml", "/appveyor.yml"]
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 once_cell = "1.9.0"
-rand = "0.8"
+rand = "0.9"
 tokio = { version = "1.40.0", features = ["sync", "time", "rt", "macros", "test-util"] }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,7 @@ impl Action {
                 return None;
             }
         }
-        if self.freq < 1f32 && !rand::thread_rng().gen_bool(f64::from(self.freq)) {
+        if self.freq < 1f32 && !rand::rng().gen_bool(f64::from(self.freq)) {
             return None;
         }
         if let Some(ref ref_cnt) = self.count {


### PR DESCRIPTION
## Summary

- Bumps `rand` from 0.8 to 0.9
- Updates `rand::thread_rng()` → `rand::rng()` (the only API change needed)
- All tests pass (`cargo test --features failpoints`)

## Motivation

`rand` 0.8 has an active RUSTSEC advisory. `fail-parallel` is the sole remaining blocker for eliminating `rand` 0.8 from slatedb's dependency tree — `quinn-proto` and `twox-hash` already have newer versions that resolve via `cargo update`.

This is a minimal change (2 lines) with no behavioral difference.